### PR TITLE
Move linting to makefile

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -14,11 +14,11 @@ jobs:
       - uses: actions/checkout@v2
         name: Checkout repository
 
-      - uses: DoozyX/clang-format-lint-action@v0.13
-        with:
-          source: 'src/'
-          extensions: 'h,c,cpp'
-          clangFormatVersion: 13.0.0
+      - name: Install clang-format
+        run: sudo apt-get install -y clang-format
+
+      - name: clang-format linter
+        run: make lint
 
   build-and-test:
     needs: linter

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,6 @@ test:
 
 lint:
 	find src/ -iname *.c -o -iname *.cpp -o -iname *.h | xargs clang-format --dry-run --Werror -style=file
+
+format:
+	find src/ -iname *.c -o -iname *.cpp -o -iname *.h | xargs clang-format -i -style=file

--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,6 @@ init_test:
 
 test:
 	cd $(TEST_DIR) && pwd && bash test.sh
+
+lint:
+	find src/ -iname *.c -o -iname *.cpp -o -iname *.h | xargs clang-format --dry-run --Werror -style=file

--- a/example/format.sh.example
+++ b/example/format.sh.example
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-find src/ -iname *.c -o -iname *.cpp -o -iname *.h | xargs clang-format -i -style=file

--- a/readme.md
+++ b/readme.md
@@ -37,9 +37,7 @@ Follow these steps:
   ```
 - If there are any linting errors, run format.sh.example to format it.
   ```
-  cp example/format.sh.example format.sh
-  chmod 0700 format.sh
-  ./format.sh
+  make format
   ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,25 @@ Calculating my GPA, in an OOP way.
 
 So simple, right?
 
+## Development
+We require your code to be formatted with `clang-format` before going further.
+Follow these steps:
+- Install `clang-format`:
+  ```
+  sudo apt-get install clang-format
+  ```
+- Run checks:
+  ```
+  make lint
+  ```
+- If there are any linting errors, run format.sh.example to format it.
+  ```
+  cp example/format.sh.example format.sh
+  chmod 0700 format.sh
+  ./format.sh
+  ```
+
+
 ## Running
 ### 1. Input format
 - The input `.csv` file should looks like this:


### PR DESCRIPTION
- Move lint workflow to makefile. This will not require an external actions.
- Added guideline for developing (aka requires code to be formatted).