### PR TITLE
Update workflow: split release to a separate workflow

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -22,10 +22,7 @@ jobs:
 
   build-and-test:
     needs: linter
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: ['windows-latest', 'ubuntu-latest']
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
@@ -40,49 +37,5 @@ jobs:
     - name: make - test
       run: make test
 
-    - name: Upload artifacts (pushes only)
-      uses: actions/upload-artifact@v2
-      with:
-        name: build-executable
-        path: |
-          data/
-          main
-          main.exe
-        if-no-files-found: error
-      if: ${{ github.event_name == 'push' }}
-
     - name: cleaning afterworks
       run: make clean
-
-  create-release:
-    if: ${{ github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    needs: build-and-test
-    steps:
-      - name: Download artifacts from previous build
-        uses: actions/download-artifact@v2
-        with:
-          name: build-executable
-
-      - name: Zipping release artifact
-        uses: vimtor/action-zip@v1
-        with:
-          files: data/ main main.exe
-          recursive: false
-          dest: release.zip
-      
-      - name: Drafting a new release.
-        uses: release-drafter/release-drafter@v5
-        id: draft-new-release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload release asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.draft-new-release.outputs.upload_url }}
-          asset_path: release.zip
-          asset_name: release.zip
-          asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release-build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ['windows-latest', 'ubuntu-latest']
+
+    steps:
+    - uses: actions/checkout@v2
+      name: Checkout repository
+
+    - name: make
+      run: make
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: build-executable
+        path: |
+          data/
+          main
+          main.exe
+        if-no-files-found: error
+
+    - name: cleaning afterworks
+      run: make clean
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs: release-build
+    steps:
+      - name: Download artifacts from previous build
+        uses: actions/download-artifact@v2
+        with:
+          name: build-executable
+
+      - name: Zipping release artifact
+        uses: vimtor/action-zip@v1
+        with:
+          files: data/ main main.exe
+          recursive: false
+          dest: release.zip
+
+      - name: Drafting a new release
+        uses: release-drafter/release-drafter@v5
+        id: draft-new-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.draft-new-release.outputs.upload_url }}
+          asset_path: release.zip
+          asset_name: release.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
Resolve #74 
- c-cpp will run when there are pushes / pull requests to master branch
- release will run when there are pushes to **tags**